### PR TITLE
Fix table reactivity

### DIFF
--- a/src/lib/components/metrics/situations/SituationTable.svelte
+++ b/src/lib/components/metrics/situations/SituationTable.svelte
@@ -15,8 +15,9 @@
     tableStore = createTableStore($situations);
   }
   
-  $: filteredData = tableStore.getFilteredData();
-  $: paginatedData = tableStore.getPaginatedData(filteredData);
+  // Ensure reactive updates when the table store changes
+  $: filteredData = ($tableStore, tableStore.getFilteredData());
+  $: paginatedData = ($tableStore, tableStore.getPaginatedData(filteredData));
   
   function toggleSort(column: string) {
     tableStore.toggleSort(column);


### PR DESCRIPTION
## Summary
- ensure table rows update when filtering or sorting by referencing store in reactive statements

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f2d9bec88325881e8de11da552e5